### PR TITLE
feat: add a new noble-based implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,11 +9,18 @@
 
 	"overrides": [
 		{
+			"files": "browser.js",
+			"rules": {
+				"global-require": "off",
+			},
+		},
+		{
 			"files": [
-				"browser.js",
+				"browser.*.js",
 			],
 			"rules": {
 				"no-underscore-dangle": "warn",
+				"sort-keys": "off",
 			},
 		},
 	],

--- a/browser.js
+++ b/browser.js
@@ -1,35 +1,11 @@
 'use strict';
 
-var inherits = require('inherits');
-var MD5 = require('md5.js');
-var RIPEMD160 = require('ripemd160');
-var sha = require('sha.js');
-var Base = require('cipher-base');
-
-function Hash(hash) {
-	Base.call(this, 'digest');
-
-	this._hash = hash;
+if (typeof BigInt === 'undefined') {
+	module.exports = require('./browser.old.js');
+} else {
+	try {
+		module.exports = require('./browser.noble.js');
+	} catch (err) {
+		module.exports = require('./browser.old.js');
+	}
 }
-
-inherits(Hash, Base);
-
-Hash.prototype._update = function (data) {
-	this._hash.update(data);
-};
-
-Hash.prototype._final = function () {
-	return this._hash.digest();
-};
-
-module.exports = function createHash(algorithm) {
-	var alg = algorithm.toLowerCase();
-	if (alg === 'md5') {
-		return new MD5();
-	}
-	if (alg === 'rmd160' || alg === 'ripemd160') {
-		return new RIPEMD160();
-	}
-
-	return new Hash(sha(alg));
-};

--- a/browser.noble.js
+++ b/browser.noble.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var sha1 = require('@noble/hashes/sha1');
+var ripemd160 = require('@noble/hashes/ripemd160');
+var sha2 = require('@noble/hashes/sha2');
+var sha3 = require('@noble/hashes/sha3');
+var blake2b = require('@noble/hashes/blake2b');
+var blake2s = require('@noble/hashes/blake2s');
+var inherits = require('inherits');
+var MD5 = require('md5.js');
+var Base = require('cipher-base');
+var Buffer = require('safe-buffer').Buffer;
+
+function Hash(hash) {
+	Base.call(this, 'digest');
+
+	this._hash = hash;
+}
+
+inherits(Hash, Base);
+
+Hash.prototype._update = function (data) {
+	this._hash.update(data);
+};
+
+Hash.prototype._final = function () {
+	var uarr = this._hash.digest();
+	return Buffer.from(uarr.buffer, uarr.byteOffset, uarr.byteLength);
+};
+
+var hashes = {
+	// Supported by browser.old.js
+	sha1: sha1.sha1,
+	sha224: sha2.sha224,
+	sha256: sha2.sha256,
+	sha384: sha2.sha384,
+	sha512: sha2.sha512,
+	ripemd160: ripemd160.ripemd160,
+	rmd160: ripemd160.ripemd160,
+
+	// Not supported by browser.old.js (until sha.js updates?)
+	'sha512-224': sha2.sha512_224, // for browser.old.js: https://github.com/browserify/sha.js/pull/67
+	'sha512-256': sha2.sha512_256, // for browser.old.js: https://github.com/browserify/sha.js/pull/67
+	'sha3-224': sha3.sha3_224,
+	'sha3-256': sha3.sha3_256,
+	'sha3-384': sha3.sha3_384,
+	'sha3-512': sha3.sha3_512,
+	blake2b512: blake2b.blake2b, // 512 is the default size
+	blake2s256: blake2s.blake2s // 256 is the default size
+};
+
+module.exports = function createHash(algorithm) {
+	var alg = algorithm.toLowerCase();
+
+	if (alg === 'md5') {
+		return new MD5();
+	}
+
+	if (!Object.prototype.hasOwnProperty.call(hashes, alg)) {
+		throw new Error('Digest method not supported');
+	}
+
+	return new Hash(hashes[alg].create());
+};

--- a/browser.old.js
+++ b/browser.old.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var inherits = require('inherits');
+var MD5 = require('md5.js');
+var RIPEMD160 = require('ripemd160');
+var sha = require('sha.js');
+var Base = require('cipher-base');
+
+function Hash(hash) {
+	Base.call(this, 'digest');
+
+	this._hash = hash;
+}
+
+inherits(Hash, Base);
+
+Hash.prototype._update = function (data) {
+	this._hash.update(data);
+};
+
+Hash.prototype._final = function () {
+	return this._hash.digest();
+};
+
+module.exports = function createHash(algorithm) {
+	var alg = algorithm.toLowerCase();
+	if (alg === 'md5') {
+		return new MD5();
+	}
+	if (alg === 'rmd160' || alg === 'ripemd160') {
+		return new RIPEMD160();
+	}
+
+	return new Hash(sha(alg));
+};

--- a/package.json
+++ b/package.json
@@ -31,13 +31,16 @@
     "md5.js": "^1.3.4",
     "readable-stream": "^2.3.8",
     "ripemd160": "^2.0.2",
+    "safe-buffer": "^5.0.1",
     "sha.js": "^2.4.11"
+  },
+  "optionalDependencies": {
+    "@noble/hashes": "^1.3.3"
   },
   "devDependencies": {
     "@ljharb/eslint-config": "^21.1.1",
     "eslint": "=8.8.0",
     "hash-test-vectors": "^1.3.2",
-    "safe-buffer": "^5.2.1",
     "tape": "^5.9.0"
   },
   "engines": {

--- a/test/index.js
+++ b/test/index.js
@@ -10,35 +10,75 @@ vectors.forEach(function (vector) {
 	// eslint-disable-next-line no-param-reassign
 	vector.ripemd160 = vector.rmd160;
 });
-var createHash = require('../browser');
+var createHashOld = require('../browser.old.js');
+var createHashAuto = require('../browser.js');
 
-algorithms.forEach(function (algorithm) {
-	test('test ' + algorithm + ' against test vectors', function (t) {
-		vectors.forEach(function (obj, i) {
-			var input = Buffer.from(obj.input, 'base64');
-			var node = obj[algorithm];
-			var js = createHash(algorithm).update(input).digest('hex');
-			t.equal(js, node, algorithm + '(testVector[' + i + ']) == ' + node);
-		});
+var implementations = [createHashOld];
+if (createHashAuto !== createHashOld) { implementations.push(createHashAuto); }
 
-		encodings.forEach(function (encoding) {
+implementations.forEach(function (createHash) {
+	algorithms.forEach(function (algorithm) {
+		test('test ' + algorithm + ' against test vectors', function (t) {
 			vectors.forEach(function (obj, i) {
-				var input = Buffer.from(obj.input, 'base64').toString(encoding);
+				var input = Buffer.from(obj.input, 'base64');
 				var node = obj[algorithm];
-				var js = createHash(algorithm).update(input, encoding).digest('hex');
-				t.equal(js, node, algorithm + '(testVector[' + i + '], ' + encoding + ') == ' + node);
+				var js = createHash(algorithm).update(input).digest('hex');
+				t.equal(js, node, algorithm + '(testVector[' + i + ']) == ' + node);
 			});
-		});
 
-		vectors.forEach(function (obj, i) {
-			var input = Buffer.from(obj.input, 'base64');
-			var node = obj[algorithm];
-			var hash = createHash(algorithm);
-			hash.end(input);
-			var js = hash.read().toString('hex');
-			t.equal(js, node, algorithm + '(testVector[' + i + ']) == ' + node);
-		});
+			encodings.forEach(function (encoding) {
+				vectors.forEach(function (obj, i) {
+					var input = Buffer.from(obj.input, 'base64').toString(encoding);
+					var node = obj[algorithm];
+					var js = createHash(algorithm).update(input, encoding).digest('hex');
+					t.equal(js, node, algorithm + '(testVector[' + i + '], ' + encoding + ') == ' + node);
+				});
+			});
 
-		t.end();
+			vectors.forEach(function (obj, i) {
+				var input = Buffer.from(obj.input, 'base64');
+				var node = obj[algorithm];
+				var hash = createHash(algorithm);
+				hash.end(input);
+				var js = hash.read().toString('hex');
+				t.equal(js, node, algorithm + '(testVector[' + i + ']) == ' + node);
+			});
+
+			t.end();
+		});
 	});
 });
+
+var createHashNode = require('crypto').createHash;
+var randomBytes = require('crypto').randomBytes;
+
+function crossTest(createHashTest, createHashBase, algs) {
+	var data = randomBytes(32);
+	test('test against base implementation', function (t) {
+		algs.forEach(function (algorithm) {
+			var a = createHashTest(algorithm).update(data).digest('hex');
+			var b;
+			try {
+				b = createHashBase(algorithm).update(data).digest('hex');
+			} catch (err) {}
+			var label = algorithm + '(' + data.toString('hex') + ')';
+			if (b) {
+				t.equal(a, b, label);
+			} else {
+				t.skip(label); // Node.js version doesn't support it
+			}
+		});
+		t.end();
+	});
+}
+
+var baseHashes = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512', 'ripemd160', 'rmd160'];
+var extraHashes = ['sha512-224', 'sha512-256', 'sha3-224', 'sha3-256', 'sha3-384', 'sha3-512', 'blake2b512', 'blake2s256'];
+
+crossTest(createHashOld, createHashNode, baseHashes);
+
+// Only new version supports additional hashes
+if (createHashAuto !== createHashOld) {
+	crossTest(createHashAuto, createHashNode, baseHashes);
+	crossTest(createHashAuto, createHashNode, extraHashes);
+}


### PR DESCRIPTION
Uses `@noble/hashes` as a polyfill in newer environments where it works

Also adds support for:
`sha512-224`, `sha512-256`, `sha3-224`, `sha3-256`, `sha3-384`, `sha3-512`, `blake2b512` and `blake2s256`

Node.js-based default `./inde.js` already supports those through Node.js/OpenSSL, so different support level shouldn't be an issue. Also, the old browser impl here doesn't limit `sha.js` list of supported hashes and the list depends on `sha.js` version / can change outside of this lib.

The new version is used only when the env supports `BigInt` _and_ when importing noble-based implementation doesn't fail

So this should be compatible with all currently supported versions and be a semver-minor change

Test changes better viewed with whitespace ignored, I had to shift the whole existing test to run it on bold old and new implementations.